### PR TITLE
Adding support to send screenshot to sentry event logging

### DIFF
--- a/lib/handlers/sentry_handler.dart
+++ b/lib/handlers/sentry_handler.dart
@@ -65,11 +65,12 @@ class SentryHandler extends ReportHandler {
       // and the code relies on File from dart:io that does not work in web
       // either because we do not have access to the file system in web.
       SentryAttachment? screenshotAttachment;
+      File? screenshotFile;
       try {
         if (report.screenshot != null && !kIsWeb) {
           final screenshotPath = report.screenshot!.path;
-          final file = File(screenshotPath);
-          final bytes = await file.readAsBytes();
+          screenshotFile = File(screenshotPath);
+          final bytes = await screenshotFile.readAsBytes();
           screenshotAttachment = SentryAttachment.fromScreenshotData(bytes);
           _printLog('Created screenshot attachment');
         }
@@ -84,6 +85,12 @@ class SentryHandler extends ReportHandler {
             ? Hint.withScreenshot(screenshotAttachment)
             : null,
       );
+
+      if (screenshotFile != null) {
+        // Cleanup screenshot file after submission to save space on device.
+        await screenshotFile.delete();
+        _printLog('Screenshot file removed from device (cleanup)');
+      }
 
       _printLog('Logged to sentry!');
       return true;


### PR DESCRIPTION
I've tested that this works for Android and I'm assuming iOS too. Sentry does not support screenshots in web and neither does catcher_2. Because of this we can use the regular dart:io File to parse the screenshot data and send it to Sentry.