### PR TITLE
Support `go_router` / `MaterialApp.router(…)`

### DIFF
--- a/lib/core/catcher_2.dart
+++ b/lib/core/catcher_2.dart
@@ -105,6 +105,9 @@ class Catcher2 implements ReportModeAction {
     }
   }
 
+  void configureNavigatorKey(GlobalKey<NavigatorState>? navigatorKey) =>
+      _configureNavigatorKey(navigatorKey);
+
   void _configureNavigatorKey(GlobalKey<NavigatorState>? navigatorKey) {
     if (navigatorKey != null) {
       _navigatorKey = navigatorKey;


### PR DESCRIPTION
Fixes #47 

This allows combining `go_router` / `MaterialApp.router(…)` with the `DialogReportMode`.
It is achieved by exposing the `_configureNavigatorKey` instance method of `Catcher2` publicly to enable updating the used `navigatorKey` after `runApp` was called.

Now users can call:

```dart
final _router = GoRouter(…);
Catcher2.getInstance().configureNavigatorKey(_router.routerDelegate.navigatorKey);
```