### PR TITLE
ReportLog: Relax restriction in device parameter reporting

### DIFF
--- a/backend/src/main/java/com/jhomlala/catcher_2/backend/ReportLog.java
+++ b/backend/src/main/java/com/jhomlala/catcher_2/backend/ReportLog.java
@@ -7,7 +7,7 @@ import java.util.Map.Entry;
 public class ReportLog {
 	private String error;
 	private String stackTrace;
-	private Map<String,String> deviceParameters;
+	private Map<String,Object> deviceParameters;
 	private Map<String,String> applicationParameters;
 	private Map<String,String> customParameters;
 	private Timestamp dateTime;
@@ -23,10 +23,10 @@ public class ReportLog {
 	public void setStackTrace(String stackTrace) {
 		this.stackTrace = stackTrace;
 	}
-	public Map<String, String> getDeviceParameters() {
+	public Map<String, Object> getDeviceParameters() {
 		return deviceParameters;
 	}
-	public void setDeviceParameters(Map<String, String> deviceParameters) {
+	public void setDeviceParameters(Map<String, Object> deviceParameters) {
 		this.deviceParameters = deviceParameters;
 	}
 	public Map<String, String> getApplicationParameters() {
@@ -61,7 +61,7 @@ public class ReportLog {
 	
 	public String getDeviceDataFormatted() {
 		String text = "<small>";
-		for (Entry<String, String> entry: deviceParameters.entrySet()) {
+		for (Entry<String, Object> entry: deviceParameters.entrySet()) {
 			text += "<b>"+entry.getKey()+"</b>:"+entry.getValue() +"<br>";
 		}
 		text += "</small>";


### PR DESCRIPTION
The sample backend is too strict when deserialising deviceParameters. Browsers may (recently do?) report arrays (e.g. languages):

> "deviceParameters":{"language":"de-DE","appCodeName":"Mozilla","appName":"Netscape","appVersion":"5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36","browserName":"BrowserName.chrome","deviceMemory":8,"hardwareConcurrency":16,"languages":["de-DE","de","en-US","en"],"maxTouchPoints":0,"platform":"Win32","product":"Gecko","productSub":"20030107","userAgent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36","vendor":"Google Inc.","vendorSub":""}

Relaxed deserialisation to allow any object